### PR TITLE
Now Playing: header summary metrics + message control (closes #26)

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -6,6 +6,7 @@ import {
   MovieStats,
   SeriesStats,
   NowEntry,
+  NowPlayingSummary,
   OverviewData,
   QualityBuckets,
   RefreshState,
@@ -156,6 +157,9 @@ export const fetchRefreshStatus = () => j<RefreshState>("/admin/refresh/status")
 
 // Now Playing snapshot (HTTP)
 export const fetchNowSnapshot = () => j<NowEntry[]>("/now/snapshot");
+
+// Now Playing summary metrics (lightweight)
+export const fetchNowPlayingSummary = () => j<NowPlayingSummary>("/api/now-playing/summary");
 
 // Image helpers
 export const imgPrimary = (id: string) => `${API_BASE}/img/primary/${id}`;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -79,6 +79,13 @@ export type NowEntry = {
   hdr10?: boolean;
 };
 
+// Lightweight Now Playing header summary
+export type NowPlayingSummary = {
+  outbound_mbps: number;
+  active_streams: number;
+  active_transcodes: number;
+};
+
 export type PlayMethodCounts = {
   methods: {
     DirectPlay?: number;

--- a/go/cmd/emby-analytics/main.go
+++ b/go/cmd/emby-analytics/main.go
@@ -258,6 +258,7 @@ func main() {
 	app.Get("/img/primary/:id", images.Primary(imgOpts))
 	app.Get("/img/backdrop/:id", images.Backdrop(imgOpts))
 	// Now Playing Routes
+	app.Get("/api/now-playing/summary", now.Summary)
 	app.Get("/now/snapshot", now.Snapshot)
 	app.Get("/now/ws", func(c fiber.Ctx) error {
 		if ws.IsWebSocketUpgrade(c) {

--- a/go/internal/handlers/now/summary.go
+++ b/go/internal/handlers/now/summary.go
@@ -1,0 +1,134 @@
+package now
+
+import (
+    "math"
+    "strings"
+    "sync"
+
+    "github.com/gofiber/fiber/v3"
+)
+
+// NowPlayingSummary is a compact metrics payload for the Now Playing header.
+// outbound_mbps is a 5-sample rolling average of all active session bitrates.
+type NowPlayingSummary struct {
+    OutboundMbps     float64 `json:"outbound_mbps"`
+    ActiveStreams    int     `json:"active_streams"`
+    ActiveTranscodes int     `json:"active_transcodes"`
+}
+
+// ring buffer for smoothing outbound_mbps (approx 5s window at 1s+ polling)
+type mbpsRing struct {
+    mu   sync.Mutex
+    buf  []float64
+    next int
+    size int
+}
+
+func newMbpsRing(n int) *mbpsRing {
+    if n <= 0 {
+        n = 5
+    }
+    return &mbpsRing{buf: make([]float64, n), next: 0, size: 0}
+}
+
+func (r *mbpsRing) add(v float64) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.buf[r.next] = v
+    r.next = (r.next + 1) % len(r.buf)
+    if r.size < len(r.buf) {
+        r.size++
+    }
+}
+
+func (r *mbpsRing) avgOr(v float64) float64 {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    if r.size == 0 {
+        return v
+    }
+    sum := 0.0
+    for i := 0; i < r.size; i++ {
+        sum += r.buf[i]
+    }
+    return sum / float64(r.size)
+}
+
+var summaryRing = newMbpsRing(5)
+
+// Summary computes the lightweight metrics for the Now Playing header.
+// GET /api/now-playing/summary
+func Summary(c fiber.Ctx) error {
+    em, err := getEmbyClient()
+    if err != nil {
+        // If server is not configured, return zeros gracefully
+        return c.Status(fiber.StatusOK).JSON(NowPlayingSummary{})
+    }
+
+    sessions, err := em.GetActiveSessions()
+    if err != nil {
+        // On upstream error, still return zeros to avoid breaking UI
+        return c.Status(fiber.StatusOK).JSON(NowPlayingSummary{})
+    }
+
+    active := 0
+    transcodes := 0
+    var sumBps int64
+
+    for _, s := range sessions {
+        // Active stream: not paused (buffering isn't exposed; best effort)
+        if s.IsPaused {
+            continue
+        }
+        active++
+
+        // Determine if this session is doing any A/V or subtitle transcode
+        isTrans := false
+        if !strings.EqualFold(s.PlayMethod, "Direct") {
+            isTrans = true
+        }
+        if strings.EqualFold(s.VideoMethod, "Transcode") || strings.EqualFold(s.AudioMethod, "Transcode") {
+            isTrans = true
+        }
+        // Heuristic: subtitles/burn-in indicated by reasons
+        if !isTrans && len(s.TransReasons) > 0 {
+            for _, r := range s.TransReasons {
+                rr := strings.ToLower(r)
+                if strings.Contains(rr, "subtitle") || strings.Contains(rr, "burn") {
+                    isTrans = true
+                    break
+                }
+            }
+        }
+        if isTrans {
+            transcodes++
+        }
+
+        // Bitrate selection: prefer overall session bitrate; fallback to target A/V bitrates
+        bps := s.Bitrate
+        if bps <= 0 {
+            if s.TransVideoBitrate > 0 || s.TransAudioBitrate > 0 {
+                bps = s.TransVideoBitrate + s.TransAudioBitrate
+            }
+        }
+        if bps > 0 {
+            sumBps += bps
+        }
+    }
+
+    // Convert to Mbps, round to 1 decimal
+    mbps := float64(sumBps) / 1_000_000.0
+    if mbps < 0 {
+        mbps = 0
+    }
+    // Smooth over last ~5 samples
+    summaryRing.add(mbps)
+    avg := summaryRing.avgOr(mbps)
+    avg = math.Round(avg*10) / 10
+
+    return c.JSON(NowPlayingSummary{
+        OutboundMbps:     avg,
+        ActiveStreams:    active,
+        ActiveTranscodes: transcodes,
+    })
+}


### PR DESCRIPTION
This PR adds lightweight "Now Playing summary" metrics and surfaces them beside the Now Playing header.

API
- GET  returns:
  - : 5s rolling average of sum of active session bitrates (1 decimal)
  - : count of non-paused sessions
  - : sessions with any A/V/subtitle transcode

Backend
- Fiber v3 route wired in .
- Aggregation based on Emby sessions (prefers ; falls back to target A/V bitrates). Guards zero/missing.
- 5-sample in-memory ring buffer to smooth outbound Mbps over ~5s.

Frontend (React/TS)
- Header pills beside the "Now Playing" text:
  - Outbound: {outbound_mbps} Mbps
  - Streams: {active_streams}
  - Transcodes: {active_transcodes}
- Polls the summary every 5s.
- Added inline Message box per card (opens next to buttons) using existing  API.
- Small spacing/placeholder tweaks; kept the bottom placeholder to align heights when other cards are transcoding.

Config
- Uses existing EMBY_BASE_URL and EMBY_API_KEY via existing .

Acceptance
- Endpoint returns sane values; UI updates within 5s.
- No breaking route changes; typecheck/build pass.

Closes #26.