### PR TITLE
Block 4K video transcoding with user notification

### DIFF
--- a/app/src/pages/settings.tsx
+++ b/app/src/pages/settings.tsx
@@ -32,6 +32,7 @@ export default function SettingsPage() {
   };
 
   const includeTrakt = settings?.find((s) => s.key === "include_trakt_items")?.value || "false";
+  const prevent4kTranscoding = settings?.find((s) => s.key === "prevent_4k_video_transcoding")?.value || "false";
   const [meRole, setMeRole] = useState<string | null>(null);
   const [users, setUsers] = useState<AppUser[] | null>(null);
   const [usersError, setUsersError] = useState<string | null>(null);
@@ -84,7 +85,7 @@ export default function SettingsPage() {
     if (meRole && meRole.toLowerCase() === "admin") {
       loadUsers();
     }
-  }, [meRole]);
+  }, [meRole, loadUsers]);
 
   if (isLoading) {
     return (
@@ -254,6 +255,83 @@ export default function SettingsPage() {
                   Changes to this setting will take effect the next time user data is synced (every
                   12 hours by default, or when manually triggered via the admin panel). The new
                   calculation will be applied to all users.
+                </p>
+              </div>
+            </div>
+
+            <div className="bg-neutral-800 rounded-lg p-6 mt-6">
+              <h2 className="text-lg font-semibold mb-4">Performance Settings</h2>
+
+              <div className="space-y-4">
+                <div className="flex items-center justify-between p-4 bg-neutral-700/50 rounded-lg">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 mb-2">
+                      <label htmlFor="prevent_4k_video_transcoding" className="text-white font-medium">
+                        Prevent 4K Video Transcoding
+                      </label>
+                      {saveStatus?.key === "prevent_4k_video_transcoding" && (
+                        <div
+                          className={`flex items-center gap-1 text-sm ${
+                            saveStatus.status === "success" ? "text-green-400" : "text-red-400"
+                          }`}
+                        >
+                          {saveStatus.status === "success" ? (
+                            <>
+                              <Check className="w-4 h-4 text-green-400" />
+                              <span>Saved</span>
+                            </>
+                          ) : (
+                            <>
+                              <AlertCircle className="w-4 h-4 text-red-400" />
+                              <span>Error saving</span>
+                            </>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <p className="text-gray-400 text-sm mb-3">
+                      Automatically stops sessions when 4K video transcoding is detected to prevent server overload.
+                      Audio and subtitle transcoding on 4K content will continue normally as they have minimal performance impact.
+                    </p>
+                    <div className="flex items-start gap-2 text-xs text-blue-300 bg-blue-900/20 border border-blue-500/30 rounded p-3">
+                      <Info className="w-4 h-4 mt-0.5 flex-shrink-0 text-blue-400" />
+                      <div>
+                        <strong>How it works:</strong> This setting monitors active sessions and automatically stops 
+                        those transcoding 4K video content. Users will receive a standard Emby &quot;session stopped&quot; 
+                        notification. Only video transcoding is blocked - audio conversion and subtitle burn-in 
+                        continue to work normally for better user experience.
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-3 ml-6">
+                    {saving === "prevent_4k_video_transcoding" && (
+                      <RotateCcw className="w-4 h-4 text-gray-400 animate-spin" />
+                    )}
+                    <button
+                      id="prevent_4k_video_transcoding"
+                      onClick={() => handleToggleChange("prevent_4k_video_transcoding", prevent4kTranscoding)}
+                      disabled={saving === "prevent_4k_video_transcoding"}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-neutral-900 ${
+                        prevent4kTranscoding === "true" ? "bg-amber-600" : "bg-neutral-600"
+                      } ${saving === "prevent_4k_video_transcoding" ? "opacity-50 cursor-not-allowed" : ""}`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          prevent4kTranscoding === "true" ? "translate-x-6" : "translate-x-1"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-6 p-4 bg-neutral-700/30 rounded-lg border border-neutral-600">
+                <h3 className="text-sm font-medium text-gray-300 mb-2">Performance Impact</h3>
+                <p className="text-sm text-gray-400">
+                  4K video transcoding can consume significant CPU/GPU resources and impact server performance 
+                  for all users. This setting helps maintain server stability by preventing the most 
+                  resource-intensive transcoding operations while preserving user experience for audio and subtitle features.
                 </p>
               </div>
             </div>

--- a/go/cmd/emby-analytics/main.go
+++ b/go/cmd/emby-analytics/main.go
@@ -24,6 +24,7 @@ import (
 	stats "emby-analytics/internal/handlers/stats"
 	"emby-analytics/internal/logging"
 	"emby-analytics/internal/middleware"
+	"emby-analytics/internal/monitors"
 	"emby-analytics/internal/sync"
 	tasks "emby-analytics/internal/tasks"
 
@@ -389,6 +390,12 @@ func main() {
 	logger.Info("Starting cleanup scheduler")
 	cleanupScheduler := tasks.NewCleanupScheduler(sqlDB, em, sessionProcessor.Intervalizer)
 	cleanupScheduler.Start()
+
+	// Start 4K video transcoding monitor
+	logger.Info("Starting 4K video transcoding monitor")
+	transcodingMonitor := monitors.NewTranscodingMonitor(sqlDB, em, 30*time.Second)
+	transcodingMonitor.Start()
+	defer transcodingMonitor.Stop()
 
 	// Add scheduler stats endpoint (protected)
 	app.Get("/admin/scheduler/stats", adminAuth, func(c fiber.Ctx) error {

--- a/go/internal/handlers/settings/settings.go
+++ b/go/internal/handlers/settings/settings.go
@@ -84,6 +84,8 @@ func isValidSetting(key, value string) bool {
 	switch key {
 	case "include_trakt_items":
 		return value == "true" || value == "false"
+	case "prevent_4k_video_transcoding":
+		return value == "true" || value == "false"
 	default:
 		return false // Only allow known settings
 	}

--- a/go/internal/monitors/transcoding_monitor.go
+++ b/go/internal/monitors/transcoding_monitor.go
@@ -1,0 +1,198 @@
+package monitors
+
+import (
+    "database/sql"
+    "fmt"
+    "regexp"
+    "strings"
+    "sync"
+    "time"
+
+    "emby-analytics/internal/emby"
+    "emby-analytics/internal/handlers/settings"
+    "emby-analytics/internal/logging"
+)
+
+// TranscodingMonitor monitors active sessions and stops 4K video transcoding when enabled
+type TranscodingMonitor struct {
+	db       *sql.DB
+	emby     *emby.Client
+	quit     chan struct{}
+	wg       sync.WaitGroup
+	interval time.Duration
+}
+
+// NewTranscodingMonitor creates a new transcoding monitor
+func NewTranscodingMonitor(db *sql.DB, embyClient *emby.Client, interval time.Duration) *TranscodingMonitor {
+	if interval <= 0 {
+		interval = 30 * time.Second // Default 30 seconds
+	}
+
+	return &TranscodingMonitor{
+		db:       db,
+		emby:     embyClient,
+		quit:     make(chan struct{}),
+		interval: interval,
+	}
+}
+
+// Start begins monitoring for 4K video transcoding
+func (tm *TranscodingMonitor) Start() {
+	tm.wg.Add(1)
+	go tm.monitorLoop()
+	logging.Info("4K video transcoding monitor started", "interval", tm.interval)
+}
+
+// Stop gracefully stops the monitor
+func (tm *TranscodingMonitor) Stop() {
+	close(tm.quit)
+	tm.wg.Wait()
+	logging.Info("4K video transcoding monitor stopped")
+}
+
+// monitorLoop is the main monitoring loop
+func (tm *TranscodingMonitor) monitorLoop() {
+	defer tm.wg.Done()
+	
+	ticker := time.NewTicker(tm.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-tm.quit:
+			return
+		case <-ticker.C:
+			if tm.isMonitoringEnabled() {
+				tm.checkAndStopTranscodingSessions()
+			}
+		}
+	}
+}
+
+// isMonitoringEnabled checks if the setting is enabled
+func (tm *TranscodingMonitor) isMonitoringEnabled() bool {
+	return settings.GetSettingBool(tm.db, "prevent_4k_video_transcoding", false)
+}
+
+// checkAndStopTranscodingSessions checks active sessions and stops 4K video transcoding
+func (tm *TranscodingMonitor) checkAndStopTranscodingSessions() {
+	sessions, err := tm.emby.GetActiveSessions()
+	if err != nil {
+		logging.Debug("Failed to get active sessions for transcoding monitor", "error", err)
+		return
+	}
+
+	for _, session := range sessions {
+        if tm.shouldStopSession(session) {
+            logging.Info("Stopping 4K video transcoding session", 
+                "session_id", session.SessionID,
+                "user", session.UserName,
+                "item", session.ItemName,
+                "device", session.Device)
+
+            // Try to notify the user on the client before stopping playback
+            // so it doesn't feel like an unexplained interruption.
+            header := "4K Transcoding Blocked"
+            body := fmt.Sprintf("This server blocks 4K video transcoding. Item: %s. Try a lower quality or direct play.", strings.TrimSpace(session.ItemName))
+            if err := tm.emby.SendMessage(session.SessionID, header, body, 5000); err != nil {
+                logging.Debug("Failed to send session message before stop", "error", err, "session_id", session.SessionID)
+            } else {
+                // Small delay to give the client a chance to render the message
+                time.Sleep(750 * time.Millisecond)
+            }
+
+            if err := tm.emby.Stop(session.SessionID); err != nil {
+                logging.Error("Failed to stop 4K video transcoding session", 
+                    "error", err,
+                    "session_id", session.SessionID,
+                    "user", session.UserName)
+            } else {
+                logging.Info("Successfully stopped 4K video transcoding session", 
+                    "session_id", session.SessionID,
+                    "user", session.UserName,
+                    "item", session.ItemName)
+            }
+        }
+    }
+}
+
+// shouldStopSession determines if a session should be stopped based on 4K video transcoding
+func (tm *TranscodingMonitor) shouldStopSession(session emby.EmbySession) bool {
+	// Check if there's a playing item
+	if session.ItemID == "" {
+		return false
+	}
+
+	// Check if this is 4K content
+	if !tm.is4KContent(session) {
+		return false
+	}
+
+	// Check if video is being transcoded (this is the key check)
+	if !tm.isVideoTranscoding(session) {
+		return false
+	}
+
+	return true
+}
+
+// is4KContent determines if the content being played is 4K resolution
+func (tm *TranscodingMonitor) is4KContent(session emby.EmbySession) bool {
+	// Check width directly from session (4K is typically 1921-3840 pixels wide)
+	if session.Width >= 1921 && session.Width <= 3840 {
+		return true
+	}
+
+	// Fallback: check item name for 4K indicators
+	if session.ItemName != "" {
+		displayTitle := strings.ToLower(session.ItemName)
+		if tm.contains4KMarker(displayTitle) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains4KMarker checks if a string contains 4K resolution markers
+func (tm *TranscodingMonitor) contains4KMarker(text string) bool {
+	// Regex to match 4K resolution indicators
+	pattern := regexp.MustCompile(`\b(4k|2160p)\b`)
+	return pattern.MatchString(text)
+}
+
+// isVideoTranscoding determines if video is being transcoded in the session
+func (tm *TranscodingMonitor) isVideoTranscoding(session emby.EmbySession) bool {
+    // Check VideoMethod for direct video transcoding indication
+    if strings.ToLower(session.VideoMethod) == "transcode" {
+        return true
+    }
+
+    // Check if video codec is being converted (transcoded)
+    if session.TransVideoFrom != "" && session.TransVideoTo != "" {
+        // If source and target codecs are different, video is being transcoded
+        if strings.ToLower(session.TransVideoFrom) != strings.ToLower(session.TransVideoTo) {
+            return true
+        }
+    }
+
+    // Look at explicit transcode reasons for video-related causes
+    if len(session.TransReasons) > 0 {
+        reasons := strings.ToLower(strings.Join(session.TransReasons, ","))
+        videoIndicators := []string{
+            "videocodecnotsupported", "video codec not supported",
+            "videoprofilenotsupported", "video profile not supported",
+            "videolevelnotsupported", "video level not supported",
+            "videoframeratenotsupported", "video framerate not supported",
+            "videobitratenotsupported", "video bitrate not supported",
+            "videoresolutionnotsupported", "video resolution not supported",
+        }
+        for _, ind := range videoIndicators {
+            if strings.Contains(reasons, ind) {
+                return true
+            }
+        }
+    }
+
+    return false
+}


### PR DESCRIPTION
Summary:\n- Adds Settings option to block 4K video transcoding.\n- Sends an in-session message before stopping playback.\n\nUser-visible changes:\n- New toggle: Prevent 4K Video Transcoding in Settings.\n- Users see a clear message before a 4K transcode session is stopped.\n\nNotes:\n- closes #34