### PR TITLE
fix(header): correct Streams direct/transcode counts and add colors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This repository uses a tag-driven release workflow and a branch-first developmen
 - When the user asks to “commit each step, but don’t push”, respect it: commit locally and wait.
 - Ask for confirmation before pushing, merging, or tagging.
 - Include issue references when applicable, e.g., `closes #24`.
+- Before adding an issue reference, run `gh issue list` to check for a relevant open issue and then confirm with the user whether it’s okay to link/close it (e.g., `closes #123`). Only include the reference after explicit user approval.
 
 ## PR Preparation
 
@@ -44,4 +45,3 @@ This repository uses a tag-driven release workflow and a branch-first developmen
 
 - Avoid destructive operations (resets, force pushes) unless explicitly requested.
 - Never publish images or tags without explicit user approval.
-

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -20,9 +20,8 @@ export default function Header() {
   // Derived UI counters
   const weeklyHours = weeklyUsage.reduce((acc, r) => acc + (r.hours || 0), 0);
   const streamsTotal = nowPlaying.length;
-  const directPlay = nowPlaying.filter(
-    (s: SnapshotEntry) => s.play_method === "DirectPlay" || s.play_method === "DirectStream"
-  ).length;
+  // Backend provides play_method as "Direct" or "Transcode".
+  const directPlay = nowPlaying.filter((s: SnapshotEntry) => s.play_method !== "Transcode").length;
   const transcoding = streamsTotal - directPlay;
 
   // Progress %
@@ -147,8 +146,12 @@ export default function Header() {
                 <>
                   {streamsTotal}
                   {streamsTotal > 0 && (
-                    <span className="text-sm text-gray-400 ml-1">
-                      ({directPlay}D/{transcoding}T)
+                    <span className="text-sm ml-1">
+                      (
+                      <span className="text-green-400">{directPlay}D</span>
+                      /
+                      <span className="text-orange-400">{transcoding}T</span>
+                      )
                     </span>
                   )}
                 </>


### PR DESCRIPTION
Problem
- Streams indicator showed 3(0D/3T) while playing 2 Direct and 1 Transcode, due to mismatched play method strings.

Approach
- Count Direct vs Transcode using backend-provided play_method values ("Direct" vs "Transcode").
- Treat any non-Transcode as Direct for safety.
- Add subtle colors to counts: D in green, T in orange.

Changes
- app/src/components/Header.tsx: fix counting logic and render colored D/T badge.
- AGENTS.md: note to run `gh issue list` and confirm with user before linking issues in commits.

User-visible
- Header "Streams" now shows accurate counts, e.g. 3 (2D/1T), with color cues.

CI/Workflow
- No CI or release changes. Tag-based image publishing remains unchanged.

Closes #40.
