### PR TITLE
fix: Use file_size_bytes column name in storage analytics

### DIFF
--- a/go/internal/handlers/stats/storage.go
+++ b/go/internal/handlers/stats/storage.go
@@ -76,16 +76,16 @@ func StaleContent(db *sql.DB) fiber.Handler {
 				li.item_type,
 				li.server_id,
 				COALESCE(ms.name, '') as server_name,
-				li.file_size / 1073741824.0 as size_gb,
+				li.file_size_bytes / 1073741824.0 as size_gb,
 				li.created_at
 			FROM library_item li
 			LEFT JOIN play_sessions ps ON li.id = ps.library_item_id
 			LEFT JOIN media_server ms ON li.server_id = ms.id
 			WHERE ps.id IS NULL 
-				AND li.file_size > 0 
+				AND li.file_size_bytes > 0 
 				AND li.deleted_at IS NULL
 			GROUP BY li.id
-			ORDER BY li.file_size DESC
+			ORDER BY li.file_size_bytes DESC
 			LIMIT ?
 		`, limit)
 		if err != nil {
@@ -133,12 +133,12 @@ func ROIAnalysis(db *sql.DB) fiber.Handler {
 				COALESCE(ms.name, '') as server_name,
 				COUNT(ps.id) as play_count,
 				SUM(ps.watch_seconds) / 3600.0 as total_watch_hours,
-				li.file_size / 1073741824.0 as size_gb,
-				(SUM(ps.watch_seconds) / 3600.0) / (li.file_size / 1073741824.0) as hours_per_gb
+				li.file_size_bytes / 1073741824.0 as size_gb,
+				(SUM(ps.watch_seconds) / 3600.0) / (li.file_size_bytes / 1073741824.0) as hours_per_gb
 			FROM library_item li
 			LEFT JOIN play_sessions ps ON li.id = ps.library_item_id
 			LEFT JOIN media_server ms ON li.server_id = ms.id
-			WHERE li.file_size > 0 AND li.deleted_at IS NULL
+			WHERE li.file_size_bytes > 0 AND li.deleted_at IS NULL
 			GROUP BY li.id
 			HAVING play_count > 0
 			ORDER BY %s
@@ -180,7 +180,7 @@ func Duplicates(db *sql.DB) fiber.Handler {
 			SELECT 
 				LOWER(REPLACE(REPLACE(file_path, '\', '/'), '//', '/')) as normalized_path,
 				COUNT(*) as duplicate_count,
-				SUM(file_size) / 1073741824.0 as total_size_gb,
+				SUM(file_size_bytes) / 1073741824.0 as total_size_gb,
 				GROUP_CONCAT(id) as item_ids,
 				GROUP_CONCAT(title) as titles
 			FROM library_item

--- a/go/internal/tasks/snapshot_job.go
+++ b/go/internal/tasks/snapshot_job.go
@@ -62,7 +62,7 @@ func captureLibrarySnapshot(db *sql.DB) error {
 	err := db.QueryRow(`
 		SELECT 
 			COUNT(*), 
-			COALESCE(SUM(file_size), 0)
+			COALESCE(SUM(file_size_bytes), 0)
 		FROM library_item
 		WHERE deleted_at IS NULL
 	`).Scan(&totalItems, &totalSize)


### PR DESCRIPTION
## Problem

Storage analytics endpoints were returning 500 errors due to SQL column name mismatch.

**Root cause**: Migration 0009 created column `file_size_bytes`, but storage analytics queries referenced `file_size`.

**Error logs**:
```
[DEBUG] initial snapshot failed error=SQL logic error: no such column: file_size (1)
[ERROR] GET /stats/storage/roi - 500
[ERROR] GET /stats/storage/stale-content - 500
[ERROR] GET /stats/storage/duplicates - 500
```

## Changes

Fixed column name in all SQL queries:

- `go/internal/handlers/stats/storage.go` - 7 occurrences in:
  - `StaleContent()` - stale item detection
  - `ROIAnalysis()` - watch hours per GB calculation
  - `Duplicates()` - duplicate file detection
- `go/internal/tasks/snapshot_job.go` - 1 occurrence in daily snapshot capture

All instances of `file_size` → `file_size_bytes` to match actual database schema.

## Testing

After this fix:
- ✅ Storage analytics endpoints return 200 OK
- ✅ Snapshot job captures daily metrics successfully
- ✅ Dashboard displays storage data correctly

## Related

- Fixes issues introduced in v0.5.0 (#53)
- Migration 0009: `0009_add_media_size_bitrate.up.sql` (defines `file_size_bytes` column)