### PR TITLE
fix: storage analytics schema corrections and UX improvements

### DIFF
--- a/app/src/pages/storage-analytics.tsx
+++ b/app/src/pages/storage-analytics.tsx
@@ -11,7 +11,6 @@ interface StaleContentItem {
   title: string;
   item_type: string;
   server_id: string;
-  server_name: string;
   size_gb: number;
   added_at?: string;
   file_path?: string;
@@ -22,7 +21,6 @@ interface ROIItem {
   title: string;
   item_type: string;
   server_id: string;
-  server_name: string;
   play_count: number;
   watch_hours: number;
   size_gb: number;
@@ -60,6 +58,18 @@ async function fetcher(url: string) {
   const res = await fetch(url);
   if (!res.ok) throw new Error("Failed to fetch");
   return res.json();
+}
+
+/** Format a value in GB to the most appropriate unit (GB, TB, PB, EB). */
+function formatSizeGB(gb: number): string {
+  const units = ["GB", "TB", "PB", "EB"];
+  let value = gb;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(2)} ${units[unitIndex]}`;
 }
 
 export default function StorageAnalyticsPage() {
@@ -160,13 +170,15 @@ export default function StorageAnalyticsPage() {
             <div className="bg-neutral-800 border border-neutral-700 rounded-lg p-4">
               <div className="text-sm text-gray-400 mb-1">Current Storage</div>
               <div className="text-2xl font-bold text-white">
-                {predictionsData ? `${predictionsData.current_size_gb.toFixed(2)} GB` : "—"}
+                {predictionsData && predictionsData.current_size_gb > 0
+                  ? formatSizeGB(predictionsData.current_size_gb)
+                  : "—"}
               </div>
             </div>
             <div className="bg-neutral-800 border border-neutral-700 rounded-lg p-4">
               <div className="text-sm text-gray-400 mb-1">Stale Content Size</div>
               <div className="text-2xl font-bold text-amber-400">
-                {totalStaleSize > 0 ? `${totalStaleSize.toFixed(2)} GB` : "—"}
+                {totalStaleSize > 0 ? formatSizeGB(totalStaleSize) : "—"}
               </div>
               <div className="text-xs text-gray-500 mt-1">
                 {staleItems.length} items never played
@@ -175,15 +187,25 @@ export default function StorageAnalyticsPage() {
             <div className="bg-neutral-800 border border-neutral-700 rounded-lg p-4">
               <div className="text-sm text-gray-400 mb-1">Projected Size (6mo)</div>
               <div className="text-2xl font-bold text-blue-400">
-                {predictionsData ? `${predictionsData.projected_size_gb_6mo.toFixed(2)} GB` : "—"}
+                {predictionsData && predictionsData.projected_size_gb_6mo > 0
+                  ? formatSizeGB(predictionsData.projected_size_gb_6mo)
+                  : "—"}
               </div>
               <div className="text-xs text-gray-500 mt-1">
-                {predictionsData
-                  ? `+${predictionsData.growth_rate_gb_per_day.toFixed(2)} GB/day`
+                {predictionsData && predictionsData.growth_rate_gb_per_day > 0
+                  ? `+${formatSizeGB(predictionsData.growth_rate_gb_per_day)}/day`
                   : ""}
               </div>
             </div>
           </div>
+
+          {/* Accuracy Warning */}
+          {predictionsData?.message && (
+            <div className="bg-amber-900/20 border border-amber-700/50 rounded-lg px-4 py-3 flex items-start gap-3">
+              <TrendingUp className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
+              <p className="text-sm text-amber-200">{predictionsData.message}</p>
+            </div>
+          )}
 
           {/* Storage Predictions */}
           <div className="bg-neutral-800 border border-neutral-700 rounded-lg p-6">
@@ -191,9 +213,7 @@ export default function StorageAnalyticsPage() {
               <TrendingUp className="w-5 h-5 text-blue-400" />
               <h2 className="text-xl font-semibold text-white">Storage Growth Forecast</h2>
             </div>
-            {predictionsData?.message ? (
-              <div className="text-gray-400 text-sm">{predictionsData.message}</div>
-            ) : chartData.length > 0 ? (
+            {chartData.length > 0 ? (
               <div style={{ height: 300 }}>
                 <ResponsiveLine
                   data={chartData}
@@ -281,7 +301,7 @@ export default function StorageAnalyticsPage() {
                     <th className="text-left p-3 font-semibold text-gray-300">Title</th>
                     <th className="text-left p-3 font-semibold text-gray-300">Type</th>
                     <th className="text-left p-3 font-semibold text-gray-300">Server</th>
-                    <th className="text-right p-3 font-semibold text-gray-300">Size (GB)</th>
+                    <th className="text-right p-3 font-semibold text-gray-300">Size</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -296,9 +316,9 @@ export default function StorageAnalyticsPage() {
                     <tr key={item.id} className="border-b border-neutral-700 hover:bg-neutral-750">
                       <td className="p-3 text-white">{item.title}</td>
                       <td className="p-3 text-gray-400">{item.item_type}</td>
-                      <td className="p-3 text-gray-400">{item.server_name || item.server_id}</td>
+                      <td className="p-3 text-gray-400">{item.server_id}</td>
                       <td className="p-3 text-right text-amber-400 font-mono">
-                        {item.size_gb.toFixed(2)}
+                        {formatSizeGB(item.size_gb)}
                       </td>
                     </tr>
                   ))}
@@ -331,7 +351,7 @@ export default function StorageAnalyticsPage() {
                     <th className="text-left p-3 font-semibold text-gray-300">Type</th>
                     <th className="text-right p-3 font-semibold text-gray-300">Plays</th>
                     <th className="text-right p-3 font-semibold text-gray-300">Watch Hours</th>
-                    <th className="text-right p-3 font-semibold text-gray-300">Size (GB)</th>
+                    <th className="text-right p-3 font-semibold text-gray-300">Size</th>
                     <th className="text-right p-3 font-semibold text-gray-300">Hours/GB</th>
                   </tr>
                 </thead>
@@ -366,7 +386,7 @@ export default function StorageAnalyticsPage() {
                           {item.watch_hours.toFixed(1)}
                         </td>
                         <td className="p-3 text-right text-gray-400 font-mono">
-                          {item.size_gb.toFixed(2)}
+                          {formatSizeGB(item.size_gb)}
                         </td>
                         <td className={`p-3 text-right font-mono font-bold ${roiColor}`}>
                           {item.hours_per_gb.toFixed(2)}
@@ -399,7 +419,7 @@ export default function StorageAnalyticsPage() {
                       {group.normalized_path}
                     </div>
                     <div className="text-purple-400 font-bold">
-                      {group.total_size_gb.toFixed(2)} GB
+                      {formatSizeGB(group.total_size_gb)}
                     </div>
                   </div>
                   <div className="text-xs text-gray-500">

--- a/go/internal/handlers/stats/storage.go
+++ b/go/internal/handlers/stats/storage.go
@@ -10,27 +10,24 @@ import (
 
 // StaleContentItem represents an item with zero plays
 type StaleContentItem struct {
-	ID          string  `json:"id"`
-	Title       string  `json:"title"`
-	ItemType    string  `json:"item_type"`
-	ServerID    string  `json:"server_id"`
-	ServerName  string  `json:"server_name"`
-	SizeGB      float64 `json:"size_gb"`
-	AddedAt     string  `json:"added_at,omitempty"`
-	FilePath    string  `json:"file_path,omitempty"`
+	ID       string  `json:"id"`
+	Title    string  `json:"title"`
+	ItemType string  `json:"item_type"`
+	ServerID string  `json:"server_id"`
+	SizeGB   float64 `json:"size_gb"`
+	AddedAt  string  `json:"added_at,omitempty"`
 }
 
 // ROIItem represents watch hours per GB analysis
 type ROIItem struct {
-	ID          string  `json:"id"`
-	Title       string  `json:"title"`
-	ItemType    string  `json:"item_type"`
-	ServerID    string  `json:"server_id"`
-	ServerName  string  `json:"server_name"`
-	PlayCount   int     `json:"play_count"`
-	WatchHours  float64 `json:"watch_hours"`
-	SizeGB      float64 `json:"size_gb"`
-	HoursPerGB  float64 `json:"hours_per_gb"`
+	ID         string  `json:"id"`
+	Title      string  `json:"title"`
+	ItemType   string  `json:"item_type"`
+	ServerID   string  `json:"server_id"`
+	PlayCount  int     `json:"play_count"`
+	WatchHours float64 `json:"watch_hours"`
+	SizeGB     float64 `json:"size_gb"`
+	HoursPerGB float64 `json:"hours_per_gb"`
 }
 
 // DuplicateGroup represents files with the same normalized path
@@ -44,11 +41,11 @@ type DuplicateGroup struct {
 
 // StoragePrediction represents storage growth forecast
 type StoragePrediction struct {
-	HistoricalData []SnapshotData `json:"historical_data"`
-	Predictions    []PredictedData `json:"predictions"`
-	CurrentSizeGB  float64 `json:"current_size_gb"`
-	ProjectedSizeGB float64 `json:"projected_size_gb_6mo"`
-	GrowthRatePerDay float64 `json:"growth_rate_gb_per_day"`
+	HistoricalData   []SnapshotData  `json:"historical_data"`
+	Predictions      []PredictedData `json:"predictions"`
+	CurrentSizeGB    float64         `json:"current_size_gb"`
+	ProjectedSizeGB  float64         `json:"projected_size_gb_6mo"`
+	GrowthRatePerDay float64         `json:"growth_rate_gb_per_day"`
 }
 
 type SnapshotData struct {
@@ -72,18 +69,15 @@ func StaleContent(db *sql.DB) fiber.Handler {
 		rows, err := db.Query(`
 			SELECT 
 				li.id,
-				li.title,
-				li.item_type,
+				li.name,
+				li.media_type,
 				li.server_id,
-				COALESCE(ms.name, '') as server_name,
 				li.file_size_bytes / 1073741824.0 as size_gb,
 				li.created_at
 			FROM library_item li
-			LEFT JOIN play_sessions ps ON li.id = ps.library_item_id
-			LEFT JOIN media_server ms ON li.server_id = ms.id
+			LEFT JOIN play_sessions ps ON li.id = ps.item_id
 			WHERE ps.id IS NULL 
-				AND li.file_size_bytes > 0 
-				AND li.deleted_at IS NULL
+				AND li.file_size_bytes > 0
 			GROUP BY li.id
 			ORDER BY li.file_size_bytes DESC
 			LIMIT ?
@@ -96,7 +90,7 @@ func StaleContent(db *sql.DB) fiber.Handler {
 		items := []StaleContentItem{}
 		for rows.Next() {
 			var item StaleContentItem
-			if err := rows.Scan(&item.ID, &item.Title, &item.ItemType, &item.ServerID, &item.ServerName, &item.SizeGB, &item.AddedAt); err != nil {
+			if err := rows.Scan(&item.ID, &item.Title, &item.ItemType, &item.ServerID, &item.SizeGB, &item.AddedAt); err != nil {
 				continue
 			}
 			items = append(items, item)
@@ -127,18 +121,16 @@ func ROIAnalysis(db *sql.DB) fiber.Handler {
 		query := fmt.Sprintf(`
 			SELECT 
 				li.id,
-				li.title,
-				li.item_type,
+				li.name,
+				li.media_type,
 				li.server_id,
-				COALESCE(ms.name, '') as server_name,
-				COUNT(ps.id) as play_count,
-				SUM(ps.watch_seconds) / 3600.0 as total_watch_hours,
+				COUNT(DISTINCT pi.id) as play_count,
+				COALESCE(SUM(pi.duration_seconds), 0) / 3600.0 as total_watch_hours,
 				li.file_size_bytes / 1073741824.0 as size_gb,
-				(SUM(ps.watch_seconds) / 3600.0) / (li.file_size_bytes / 1073741824.0) as hours_per_gb
+				(COALESCE(SUM(pi.duration_seconds), 0) / 3600.0) / (li.file_size_bytes / 1073741824.0) as hours_per_gb
 			FROM library_item li
-			LEFT JOIN play_sessions ps ON li.id = ps.library_item_id
-			LEFT JOIN media_server ms ON li.server_id = ms.id
-			WHERE li.file_size_bytes > 0 AND li.deleted_at IS NULL
+			JOIN play_intervals pi ON li.id = pi.item_id
+			WHERE li.file_size_bytes > 0
 			GROUP BY li.id
 			HAVING play_count > 0
 			ORDER BY %s
@@ -154,16 +146,16 @@ func ROIAnalysis(db *sql.DB) fiber.Handler {
 		items := []ROIItem{}
 		for rows.Next() {
 			var item ROIItem
-			if err := rows.Scan(&item.ID, &item.Title, &item.ItemType, &item.ServerID, &item.ServerName, &item.PlayCount, &item.WatchHours, &item.SizeGB, &item.HoursPerGB); err != nil {
+			if err := rows.Scan(&item.ID, &item.Title, &item.ItemType, &item.ServerID, &item.PlayCount, &item.WatchHours, &item.SizeGB, &item.HoursPerGB); err != nil {
 				continue
 			}
 			items = append(items, item)
 		}
 
 		return c.JSON(fiber.Map{
-			"roi_items": items,
+			"roi_items":   items,
 			"total_count": len(items),
-			"sort": sortOrder,
+			"sort":        sortOrder,
 		})
 	}
 }
@@ -182,9 +174,9 @@ func Duplicates(db *sql.DB) fiber.Handler {
 				COUNT(*) as duplicate_count,
 				SUM(file_size_bytes) / 1073741824.0 as total_size_gb,
 				GROUP_CONCAT(id) as item_ids,
-				GROUP_CONCAT(title) as titles
+				GROUP_CONCAT(name) as titles
 			FROM library_item
-			WHERE file_path IS NOT NULL AND deleted_at IS NULL
+			WHERE file_path IS NOT NULL
 			GROUP BY normalized_path
 			HAVING duplicate_count > 1
 			ORDER BY total_size_gb DESC
@@ -210,7 +202,7 @@ func Duplicates(db *sql.DB) fiber.Handler {
 
 		return c.JSON(fiber.Map{
 			"duplicate_groups": groups,
-			"total_groups": len(groups),
+			"total_groups":     len(groups),
 		})
 	}
 }
@@ -240,15 +232,36 @@ func StoragePredictions(db *sql.DB) fiber.Handler {
 			historical = append(historical, snapshot)
 		}
 
+		// No snapshots at all — nothing to show
+		if len(historical) == 0 {
+			return c.JSON(fiber.Map{
+				"historical_data":        historical,
+				"predictions":            []PredictedData{},
+				"current_size_gb":        0.0,
+				"projected_size_gb_6mo":  0.0,
+				"growth_rate_gb_per_day": 0.0,
+				"message":               "No snapshots recorded yet. Storage data will appear after the first snapshot is captured.",
+			})
+		}
+
+		currentSize := historical[len(historical)-1].SizeGB
+
+		// Only 1 snapshot — show current size but can't project growth
 		if len(historical) < 2 {
 			return c.JSON(fiber.Map{
-				"historical_data": historical,
-				"predictions": []PredictedData{},
-				"current_size_gb": 0.0,
-				"projected_size_gb_6mo": 0.0,
+				"historical_data":        historical,
+				"predictions":            []PredictedData{},
+				"current_size_gb":        currentSize,
+				"projected_size_gb_6mo":  0.0,
 				"growth_rate_gb_per_day": 0.0,
-				"message": "Insufficient data for predictions. Need at least 2 snapshots.",
+				"message":               "Only 1 snapshot available. Growth predictions require at least 2 daily snapshots.",
 			})
+		}
+
+		// Build accuracy warning for small sample sizes
+		var warningMessage string
+		if len(historical) < 7 {
+			warningMessage = fmt.Sprintf("Based on %d snapshots. Predictions will become more accurate as more daily snapshots are collected.", len(historical))
 		}
 
 		// Calculate linear regression for prediction
@@ -263,14 +276,14 @@ func StoragePredictions(db *sql.DB) fiber.Handler {
 
 		// Linear regression: y = mx + b
 		slope, intercept := linearRegression(dataPoints)
-		
+
 		// Generate predictions for next 6 months (180 days)
 		lastDate, _ := time.Parse("2006-01-02", historical[len(historical)-1].Date)
 		predictions := []PredictedData{}
 		for i := 1; i <= 180; i += 7 { // Weekly predictions
 			futureDate := lastDate.AddDate(0, 0, i)
 			daysSinceFirst := futureDate.Sub(firstDate).Hours() / 24.0
-			predictedSize := slope * daysSinceFirst + intercept
+			predictedSize := slope*daysSinceFirst + intercept
 			predictions = append(predictions, PredictedData{
 				Date:   futureDate.Format("2006-01-02"),
 				SizeGB: predictedSize,
@@ -280,17 +293,19 @@ func StoragePredictions(db *sql.DB) fiber.Handler {
 		// Calculate 6-month (180 days) projection
 		futureDate180 := lastDate.AddDate(0, 6, 0)
 		daysSinceFirst180 := futureDate180.Sub(firstDate).Hours() / 24.0
-		projected6mo := slope * daysSinceFirst180 + intercept
+		projected6mo := slope*daysSinceFirst180 + intercept
 
-		currentSize := historical[len(historical)-1].SizeGB
-
-		return c.JSON(fiber.Map{
-			"historical_data": historical,
-			"predictions": predictions,
-			"current_size_gb": currentSize,
-			"projected_size_gb_6mo": projected6mo,
+		resp := fiber.Map{
+			"historical_data":        historical,
+			"predictions":            predictions,
+			"current_size_gb":        currentSize,
+			"projected_size_gb_6mo":  projected6mo,
 			"growth_rate_gb_per_day": slope,
-		})
+		}
+		if warningMessage != "" {
+			resp["message"] = warningMessage
+		}
+		return c.JSON(resp)
 	}
 }
 

--- a/go/internal/tasks/snapshot_job.go
+++ b/go/internal/tasks/snapshot_job.go
@@ -64,7 +64,6 @@ func captureLibrarySnapshot(db *sql.DB) error {
 			COUNT(*), 
 			COALESCE(SUM(file_size_bytes), 0)
 		FROM library_item
-		WHERE deleted_at IS NULL
 	`).Scan(&totalItems, &totalSize)
 	if err != nil {
 		return err
@@ -73,11 +72,11 @@ func captureLibrarySnapshot(db *sql.DB) error {
 	// Counts by type
 	rows, err := db.Query(`
 		SELECT 
-			item_type,
+			media_type,
 			COUNT(*)
 		FROM library_item
-		WHERE deleted_at IS NULL AND item_type IN ('Movie', 'Series', 'Episode')
-		GROUP BY item_type
+		WHERE media_type IN ('Movie', 'Series', 'Episode')
+		GROUP BY media_type
 	`)
 	if err != nil {
 		return err
@@ -104,14 +103,14 @@ func captureLibrarySnapshot(db *sql.DB) error {
 	qualityRows, err := db.Query(`
 		SELECT 
 			CASE
-				WHEN video_resolution >= 2160 THEN '4K'
-				WHEN video_resolution >= 1080 THEN '1080p'
-				WHEN video_resolution >= 720 THEN '720p'
+				WHEN height >= 2160 THEN '4K'
+				WHEN height >= 1080 THEN '1080p'
+				WHEN height >= 720 THEN '720p'
 				ELSE 'SD'
 			END as quality,
 			COUNT(*)
 		FROM library_item
-		WHERE deleted_at IS NULL AND video_resolution IS NOT NULL
+		WHERE height IS NOT NULL
 		GROUP BY quality
 	`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix snapshot query column names (`media_type`, `height`, `file_size_bytes`) to match actual `library_item` schema — removes references to non-existent columns (`item_type`, `video_resolution`, `deleted_at`)
- Show real current storage size with just 1 snapshot instead of returning 0.0 — split the early-return into separate 0-snapshot and 1-snapshot cases
- Add accuracy warning messages when fewer than 7 snapshots are available, displayed as an amber banner below the summary cards
- Auto-scale all size displays from GB → TB → PB → EB via a new `formatSizeGB()` helper (e.g., `183440.78 GB` now renders as `179.14 TB`)

## User-visible behavior changes

- **Current Storage** card now shows the real value even with a single snapshot (previously showed `0.00 GB` or `—`)
- **Projected Size (6mo)** card shows `—` instead of `0.00 GB` when not enough data exists for prediction
- All size values throughout the page auto-scale to the most readable unit
- Amber warning banner appears when snapshot data is limited, explaining that predictions will improve over time
- Storage Growth Forecast chart now remains visible when predictions exist, even alongside a warning message